### PR TITLE
Allow mysql2 adapter to use base inserter

### DIFF
--- a/lib/inserters.rb
+++ b/lib/inserters.rb
@@ -5,7 +5,7 @@ module BulkInsertActiveRecord
   module Inserters
     def self.factory(active_record_class)
       inserter_class = case active_record_class.connection.adapter_name.downcase
-                       when 'mssql', 'mysql', 'sqlserver' then Base
+                       when 'mssql', 'mysql', 'mysql2', 'sqlserver' then Base
                        when 'oracle' then Oracle
                        end
 

--- a/lib/inserters/oracle.rb
+++ b/lib/inserters/oracle.rb
@@ -1,3 +1,5 @@
+require_relative './base'
+
 module BulkInsertActiveRecord
   module Inserters
     # Implementation specific for Oracle


### PR DESCRIPTION
A simple change to make the base inserter work with the mysql2 adapter.